### PR TITLE
Add Cursor Cloud Agent environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+  "setup": "source /workspace/venv/pyre314/bin/activate && export TESTINPUTPATH=/workspace/nornir-testdata && export TESTOUTPUTPATH=/tmp/nornir-test-output && mkdir -p \"$TESTOUTPUTPATH\""
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `.cursor/environment.json` to configure the starting state for Cursor Cloud Agent VMs.

## What it does

Each time a Cloud Agent spins up for this repo, the setup command will:

- **Activate** the Python 3.13 venv at `/workspace/venv/pyre314/`
- **Set** `TESTINPUTPATH=/workspace/nornir-testdata` and `TESTOUTPUTPATH=/tmp/nornir-test-output`
- **Create** the test output directory

This gives future agents a consistent starting point with the correct Python environment and env vars pre-configured.

## Notes

- The 24GB test data (`nornir-testdata/`) is **not** present on the VM by default and is not downloaded by this config. The env var is set so tests that check for it can find it if manually placed.
- Further environment customization (Dockerfile, additional dependencies) can be done via [cursor.com/onboard](https://cursor.com/onboard).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://marclabconnectomics.slack.com/archives/C01BT1G6PV0/p1775109700619229?thread_ts=1775109700.619229&cid=C01BT1G6PV0)

<div><a href="https://cursor.com/agents/bc-5eb94776-6628-5a38-9507-5fea6b109527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5eb94776-6628-5a38-9507-5fea6b109527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

