### PR TITLE
Add AGENTS.md and update dev Docker image for Python 3.13

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# Nornir Development Guide
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+Nornir is a Python monorepo for 2D/3D image registration and volume construction from microscopy image sets. The active subpackages (installed in editable mode) and their dependency order:
+
+1. **nornir-shared** — shared utilities (histogram, logging, etc.)
+2. **nornir-pools** — thread/process pool abstraction (depends on nornir-shared)
+3. **nornir-imageregistration** — core image registration algorithms (depends on nornir-shared, nornir-pools)
+4. **nornir-buildmanager** — 3D volume build pipeline (depends on all above)
+5. **nornir-pyre** — GUI/CLI application (depends on all above)
+6. **dm4** — DM4 file reader (standalone)
+
+### Virtual environment
+
+- **Path:** `/workspace/venv/pyre314/`
+- **Python:** 3.13 (via deadsnakes PPA; `pyproject.toml` requires `>=3.13`)
+- **Activate:** `source /workspace/venv/pyre314/bin/activate`
+
+### Environment variables
+
+These must be set before running tests:
+
+```bash
+export TESTINPUTPATH=/workspace/nornir-testdata
+export TESTOUTPUTPATH=/tmp/nornir-test-output
+```
+
+Both are persisted in `~/.bashrc`. If they are unset in your shell, re-export them.
+
+### Installing packages
+
+All pyproject.toml files declare inter-package dependencies via git URLs (e.g. `nornir_shared @ git+https://github.com/...`). When doing local editable installs, you **must** use `--no-deps` to avoid pip trying to resolve the git URLs:
+
+```bash
+source /workspace/venv/pyre314/bin/activate
+pip install --no-deps -e nornir-shared -e nornir-pools -e nornir-imageregistration -e nornir-buildmanager -e nornir-pyre -e dm4
+```
+
+### Running tests
+
+Tests use `unittest` (not pytest). CI test patterns per subpackage:
+
+| Subpackage | Command |
+|---|---|
+| nornir-shared | `cd nornir-shared && python -m unittest discover -p 'test_Histogram*.py'` |
+| nornir-pools | `cd nornir-pools && python -m unittest discover -p 'test_nornir_pools*.py'` |
+| nornir-imageregistration | `cd nornir-imageregistration && python -m unittest discover -p 'test_grid_division*.py'` |
+| nornir-buildmanager | `cd nornir-buildmanager && python -m unittest discover -p 'test_pipelinemanager*.py'` |
+
+**Known issue:** `nornir-imageregistration` tests have a broken import chain in `test/transforms/__init__.py` (tries to import `.test` submodule). The test discovery via `unittest discover` fails due to eager imports in `test/__init__.py`. Individual test files can be run directly if needed.
+
+### Linting / type-checking
+
+```bash
+cd /workspace && pyright
+```
+
+Pyright is configured via `pyrightconfig.json` at the repo root. There are ~4000 pre-existing type errors in the codebase — focus on not introducing new ones.
+
+### ImageMagick
+
+ImageMagick is required by `nornir-buildmanager` for image format conversions. It must be installed as a system package (`sudo apt-get install -y imagemagick`). Verify with `convert --version`.
+
+### Test data
+
+Tests expect `TESTINPUTPATH` to point to extracted test data from `http://rogue1.codepharm.net/nornir-testdata.zip` (~25 GB). Use Python's `zipfile` module or `7z` to extract (standard `unzip` may fail on large files). The extraction target is `/workspace/nornir-testdata`.
+
+### Docker dev image
+
+An updated Dockerfile for the dev environment is at `nornir-docker/dev/Dockerfile`. It builds an Ubuntu 24.04 image with Python 3.13, ImageMagick 7.1.1-27, and all Python dependencies pre-installed. Mount the nornir source tree into the container and run `pip install --no-deps -e ...` to install packages in editable mode.
+
+### Optional dependencies
+
+- **cupy** (GPU acceleration): `pip install cupy>=13.0` — requires NVIDIA GPU + CUDA
+- **mkl_fft / mkl_random** (Intel MKL): optional performance packages
+
+### Notes
+
+- The `pyre` GUI requires wxPython and a display server (X11). It cannot be tested headlessly.
+- cupy/mkl_fft warnings on import are informational and can be ignored.
+- No external services (databases, message queues, etc.) are required.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up the Cursor Cloud development environment and update the dev Docker image to match current project requirements.

### Changes

* **`AGENTS.md`** — New file with Cursor Cloud development instructions covering venv activation, environment variables, editable install commands (with `--no-deps` workaround for git URL dependencies), test commands, linting, and known issues.
* **`nornir-docker/dev/Dockerfile`** — Updated from Python 3.10/`ubuntu:latest` to Python 3.13/`ubuntu:24.04`. Uses a venv, consolidates RUN layers, sets `TESTINPUTPATH`/`TESTOUTPUTPATH` env vars.
* **`nornir-docker/dev/requirements.txt`** — Updated dependency versions to match current `pyproject.toml` requirements. Added missing deps (pydantic, scikit-image, pyright, wxPython, etc.). Removed stale deps (nose, Sphinx extensions).

### Environment verification

All 6 nornir subpackages installed in editable mode and verified:

| Package | Status |
|---|---|
| nornir-shared | Histogram, logging utils work |
| nornir-pools | Thread/process pools work (9 tests pass) |
| nornir-imageregistration | AlignmentRecord, ImageStats, core imports work |
| nornir-buildmanager | volumemanager, pipelinemanager modules load |
| nornir-pyre | Module loads (GUI requires X11 display) |
| dm4 | Module loads |

### Test results

* `nornir-shared`: 4/4 tests pass
* `nornir-pools`: 9/9 tests pass (2 skipped)
* `pyright`: Runs successfully (4034 pre-existing errors, 34 warnings)
* ImageMagick 6.9.12-98 installed and verified

[hello_world_demo.log](https://cursor.com/agents/bc-17010b08-d2b3-4e23-80b3-4393cf9f5fc5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_demo.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17010b08-d2b3-4e23-80b3-4393cf9f5fc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17010b08-d2b3-4e23-80b3-4393cf9f5fc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

